### PR TITLE
Remove metadata

### DIFF
--- a/array.go
+++ b/array.go
@@ -7,14 +7,15 @@ import (
 
 // An Array struct represents the JSON schema for an array.
 type Array struct {
-	MetaData
-	Items  Schema
-	Unique bool
+	Title       string
+	Description string
+	Items       Schema
+	Unique      bool
 }
 
 // Schema returns a JSON representation of the schema.
 func (a Array) Schema() map[string]interface{} {
-	m := a.schema()
+	m := makeMetaData(a.Title, a.Description)
 	m["type"] = "array"
 	m["items"] = a.Items.Schema()
 	if a.Unique {

--- a/array_test.go
+++ b/array_test.go
@@ -5,10 +5,8 @@ import "testing"
 func TestIntegerArray(t *testing.T) {
 	testCase{
 		Schema: Array{
-			MetaData: MetaData{
-				Title:       "my-title-1",
-				Description: "my-description-1",
-			},
+			Title:       "my-title-1",
+			Description: "my-description-1",
 			Items: Integer{
 				Title:       "my-title-2",
 				Description: "my-description-2",
@@ -51,10 +49,8 @@ func TestIntegerArray(t *testing.T) {
 func TestIntegerArrayEmpty(t *testing.T) {
 	testCase{
 		Schema: Array{
-			MetaData: MetaData{
-				Title:       "my-title-1",
-				Description: "my-description-1",
-			},
+			Title:       "my-title-1",
+			Description: "my-description-1",
 			Items: Integer{
 				Title:       "my-title-2",
 				Description: "my-description-2",
@@ -94,10 +90,8 @@ func TestIntegerArrayEmpty(t *testing.T) {
 func TestUniqueIntegerArray(t *testing.T) {
 	testCase{
 		Schema: Array{
-			MetaData: MetaData{
-				Title:       "my-title-1",
-				Description: "my-description-1",
-			},
+			Title:       "my-title-1",
+			Description: "my-description-1",
 			Items: Integer{
 				Title:       "my-title-2",
 				Description: "my-description-2",

--- a/array_test.go
+++ b/array_test.go
@@ -10,12 +10,10 @@ func TestIntegerArray(t *testing.T) {
 				Description: "my-description-1",
 			},
 			Items: Integer{
-				MetaData: MetaData{
-					Title:       "my-title-2",
-					Description: "my-description-2",
-				},
-				Minimum: -240,
-				Maximum: 240,
+				Title:       "my-title-2",
+				Description: "my-description-2",
+				Minimum:     -240,
+				Maximum:     240,
 			},
 		},
 		Match: `{
@@ -58,12 +56,10 @@ func TestIntegerArrayEmpty(t *testing.T) {
 				Description: "my-description-1",
 			},
 			Items: Integer{
-				MetaData: MetaData{
-					Title:       "my-title-2",
-					Description: "my-description-2",
-				},
-				Minimum: -240,
-				Maximum: 240,
+				Title:       "my-title-2",
+				Description: "my-description-2",
+				Minimum:     -240,
+				Maximum:     240,
 			},
 		},
 		Match: `{
@@ -103,12 +99,10 @@ func TestUniqueIntegerArray(t *testing.T) {
 				Description: "my-description-1",
 			},
 			Items: Integer{
-				MetaData: MetaData{
-					Title:       "my-title-2",
-					Description: "my-description-2",
-				},
-				Minimum: -240,
-				Maximum: 240,
+				Title:       "my-title-2",
+				Description: "my-description-2",
+				Minimum:     -240,
+				Maximum:     240,
 			},
 			Unique: true,
 		},

--- a/map.go
+++ b/map.go
@@ -7,7 +7,8 @@ import (
 
 // Map specifies schema for a map from string to values.
 type Map struct {
-	MetaData
+	Title             string
+	Description       string
 	Values            Schema
 	MinimumProperties int64
 	MaximumProperties int64
@@ -15,7 +16,7 @@ type Map struct {
 
 // Schema returns a JSON representation of the schema.
 func (m Map) Schema() map[string]interface{} {
-	s := m.schema()
+	s := makeMetaData(m.Title, m.Description)
 	s["type"] = "object"
 	s["additionalProperties"] = m.Values.Schema()
 	if m.MinimumProperties != 0 {

--- a/map_test.go
+++ b/map_test.go
@@ -11,12 +11,10 @@ func TestMapInteger(t *testing.T) {
 				Description: "my-description-1",
 			},
 			Values: Integer{
-				MetaData: MetaData{
-					Title:       "my-title-2",
-					Description: "my-description-2",
-				},
-				Minimum: -240,
-				Maximum: 240,
+				Title:       "my-title-2",
+				Description: "my-description-2",
+				Minimum:     -240,
+				Maximum:     240,
 			},
 		},
 		Match: `{
@@ -63,10 +61,8 @@ func TestMapString(t *testing.T) {
 				Description: "my-description-1",
 			},
 			Values: String{
-				MetaData: MetaData{
-					Title:       "my-title-2",
-					Description: "my-description-2",
-				},
+				Title:       "my-title-2",
+				Description: "my-description-2",
 			},
 		},
 		Match: `{

--- a/map_test.go
+++ b/map_test.go
@@ -6,10 +6,8 @@ func TestMapInteger(t *testing.T) {
 	var smap map[string]int
 	testCase{
 		Schema: Map{
-			MetaData: MetaData{
-				Title:       "my-title-1",
-				Description: "my-description-1",
-			},
+			Title:       "my-title-1",
+			Description: "my-description-1",
 			Values: Integer{
 				Title:       "my-title-2",
 				Description: "my-description-2",
@@ -56,10 +54,8 @@ func TestMapString(t *testing.T) {
 	var smap map[string]string
 	testCase{
 		Schema: Map{
-			MetaData: MetaData{
-				Title:       "my-title-1",
-				Description: "my-description-1",
-			},
+			Title:       "my-title-1",
+			Description: "my-description-1",
 			Values: String{
 				Title:       "my-title-2",
 				Description: "my-description-2",

--- a/metadata.go
+++ b/metadata.go
@@ -1,22 +1,5 @@
 package schematypes
 
-// MetaData contains meta-data properties common to all schema types.
-type MetaData struct {
-	Title       string
-	Description string
-}
-
-func (s *MetaData) schema() map[string]interface{} {
-	m := make(map[string]interface{})
-	if s.Title != "" {
-		m["title"] = s.Title
-	}
-	if s.Description != "" {
-		m["description"] = s.Description
-	}
-	return m
-}
-
 func makeMetaData(title, description string) map[string]interface{} {
 	m := make(map[string]interface{})
 	if title != "" {

--- a/metadata.go
+++ b/metadata.go
@@ -16,3 +16,14 @@ func (s *MetaData) schema() map[string]interface{} {
 	}
 	return m
 }
+
+func makeMetaData(title, description string) map[string]interface{} {
+	m := make(map[string]interface{})
+	if title != "" {
+		m["title"] = title
+	}
+	if description != "" {
+		m["description"] = description
+	}
+	return m
+}

--- a/object.go
+++ b/object.go
@@ -13,7 +13,8 @@ type Properties map[string]Schema
 
 // Object specifies schema for an object.
 type Object struct {
-	MetaData
+	Title                string
+	Description          string
 	Properties           Properties
 	AdditionalProperties bool
 	Required             []string
@@ -21,7 +22,7 @@ type Object struct {
 
 // Schema returns a JSON representation of the schema.
 func (o Object) Schema() map[string]interface{} {
-	m := o.schema()
+	m := makeMetaData(o.Title, o.Description)
 	m["type"] = "object"
 	if len(o.Properties) > 0 {
 		props := make(map[string]map[string]interface{})

--- a/object_test.go
+++ b/object_test.go
@@ -5,10 +5,8 @@ import "testing"
 func TestObject(t *testing.T) {
 	testCase{
 		Schema: Object{
-			MetaData: MetaData{
-				Title:       "my-title-1",
-				Description: "my-description-1",
-			},
+			Title:       "my-title-1",
+			Description: "my-description-1",
 			Properties: Properties{
 				"int": Integer{
 					Title:       "my-title-2",
@@ -66,10 +64,8 @@ func TestObject(t *testing.T) {
 func TestOptionalPropertyObject(t *testing.T) {
 	testCase{
 		Schema: Object{
-			MetaData: MetaData{
-				Title:       "my-title-1",
-				Description: "my-description-1",
-			},
+			Title:       "my-title-1",
+			Description: "my-description-1",
 			Properties: Properties{
 				"int": Integer{
 					Title:       "my-title-2",
@@ -122,16 +118,12 @@ func TestOptionalPropertyObject(t *testing.T) {
 func TestNestedObject(t *testing.T) {
 	testCase{
 		Schema: Object{
-			MetaData: MetaData{
-				Title:       "my-title-3",
-				Description: "my-description-3",
-			},
+			Title:       "my-title-3",
+			Description: "my-description-3",
 			Properties: Properties{
 				"obj": Object{
-					MetaData: MetaData{
-						Title:       "my-title-1",
-						Description: "my-description-1",
-					},
+					Title:       "my-title-1",
+					Description: "my-description-1",
 					Properties: Properties{
 						"int": Integer{
 							Title:       "my-title-2",

--- a/object_test.go
+++ b/object_test.go
@@ -11,12 +11,10 @@ func TestObject(t *testing.T) {
 			},
 			Properties: Properties{
 				"int": Integer{
-					MetaData: MetaData{
-						Title:       "my-title-2",
-						Description: "my-description-2",
-					},
-					Minimum: -240,
-					Maximum: 240,
+					Title:       "my-title-2",
+					Description: "my-description-2",
+					Minimum:     -240,
+					Maximum:     240,
 				},
 			},
 			Required: []string{"int"},
@@ -74,12 +72,10 @@ func TestOptionalPropertyObject(t *testing.T) {
 			},
 			Properties: Properties{
 				"int": Integer{
-					MetaData: MetaData{
-						Title:       "my-title-2",
-						Description: "my-description-2",
-					},
-					Minimum: -240,
-					Maximum: 240,
+					Title:       "my-title-2",
+					Description: "my-description-2",
+					Minimum:     -240,
+					Maximum:     240,
 				},
 			},
 		},
@@ -138,12 +134,10 @@ func TestNestedObject(t *testing.T) {
 					},
 					Properties: Properties{
 						"int": Integer{
-							MetaData: MetaData{
-								Title:       "my-title-2",
-								Description: "my-description-2",
-							},
-							Minimum: -240,
-							Maximum: 240,
+							Title:       "my-title-2",
+							Description: "my-description-2",
+							Minimum:     -240,
+							Maximum:     240,
 						},
 					},
 					Required: []string{"int"},

--- a/valuetypes.go
+++ b/valuetypes.go
@@ -19,14 +19,15 @@ const (
 
 // The Integer struct represents a JSON schema for an integer.
 type Integer struct {
-	MetaData
-	Minimum int64
-	Maximum int64
+	Title       string
+	Description string
+	Minimum     int64
+	Maximum     int64
 }
 
 // Schema returns a JSON representation of the schema.
 func (i Integer) Schema() map[string]interface{} {
-	m := i.schema()
+	m := makeMetaData(i.Title, i.Description)
 	m["type"] = typeInteger
 	if i.Minimum != math.MinInt64 {
 		m["minimum"] = i.Minimum
@@ -142,14 +143,15 @@ func (i Integer) Map(data interface{}, target interface{}) error {
 
 // Number schema type.
 type Number struct {
-	MetaData
-	Minimum float64
-	Maximum float64
+	Title       string
+	Description string
+	Minimum     float64
+	Maximum     float64
 }
 
 // Schema returns a JSON representation of the schema.
 func (n Number) Schema() map[string]interface{} {
-	m := n.schema()
+	m := makeMetaData(n.Title, n.Description)
 	m["type"] = typeNumber
 	if n.Minimum != -math.MaxFloat64 {
 		m["minimum"] = n.Minimum
@@ -202,11 +204,14 @@ func (n Number) Map(data interface{}, target interface{}) error {
 }
 
 // Boolean schema type.
-type Boolean struct{ MetaData }
+type Boolean struct {
+	Title       string
+	Description string
+}
 
 // Schema returns a JSON representation of the schema.
 func (b Boolean) Schema() map[string]interface{} {
-	m := b.schema()
+	m := makeMetaData(b.Title, b.Description)
 	m["type"] = typeBoolean
 	return m
 }
@@ -243,7 +248,8 @@ func (b Boolean) Map(data interface{}, target interface{}) error {
 
 // String schema type.
 type String struct {
-	MetaData
+	Title         string
+	Description   string
 	MinimumLength int
 	MaximumLength int
 	Pattern       string
@@ -251,7 +257,7 @@ type String struct {
 
 // Schema returns a JSON representation of the schema.
 func (s String) Schema() map[string]interface{} {
-	m := s.schema()
+	m := makeMetaData(s.Title, s.Description)
 	m["type"] = typeString
 	if s.MinimumLength != 0 {
 		m["minLength"] = s.MinimumLength
@@ -321,13 +327,14 @@ func (s String) Map(data interface{}, target interface{}) error {
 
 // StringEnum schema type for enums of strings.
 type StringEnum struct {
-	MetaData
-	Options []string
+	Title       string
+	Description string
+	Options     []string
 }
 
 // Schema returns a JSON representation of the schema.
 func (s StringEnum) Schema() map[string]interface{} {
-	m := s.schema()
+	m := makeMetaData(s.Title, s.Description)
 	m["type"] = typeString
 	m["enum"] = s.Options
 	return m
@@ -375,13 +382,14 @@ func (s StringEnum) Map(data interface{}, target interface{}) error {
 
 // URI schema type for strings with format: uri.
 type URI struct {
-	MetaData
-	Options []string
+	Title       string
+	Description string
+	Options     []string
 }
 
 // Schema returns a JSON representation of the schema.
 func (s URI) Schema() map[string]interface{} {
-	m := s.schema()
+	m := makeMetaData(s.Title, s.Description)
 	m["type"] = typeString
 	m["format"] = "uri"
 	return m
@@ -444,12 +452,13 @@ func (s URI) Map(data interface{}, target interface{}) error {
 
 // DateTime schema type for strings with format: date-time.
 type DateTime struct {
-	MetaData
+	Title       string
+	Description string
 }
 
 // Schema returns a JSON representation of the schema.
 func (d DateTime) Schema() map[string]interface{} {
-	m := d.schema()
+	m := makeMetaData(d.Title, d.Description)
 	m["type"] = typeString
 	m["format"] = "date-time"
 	return m
@@ -532,7 +541,8 @@ func (d DateTime) Map(data interface{}, target interface{}) error {
 //    '1d2h3m'
 //    '   1  day  2 hour  1 minutes '
 type Duration struct {
-	MetaData
+	Title         string
+	Description   string
 	AllowNegative bool
 }
 
@@ -546,7 +556,7 @@ var signedDurationRegexp = regexp.MustCompile(`^\s*([+-])?` + durationPattern + 
 
 // Schema returns a JSON representation of the schema.
 func (d Duration) Schema() map[string]interface{} {
-	m := d.schema()
+	m := makeMetaData(d.Title, d.Description)
 	m["type"] = []string{"integer", "string"}
 	if d.AllowNegative {
 		m["pattern"] = signedDurationRegexp.String()

--- a/valuetypes_test.go
+++ b/valuetypes_test.go
@@ -41,12 +41,10 @@ var (
 func TestInteger(t *testing.T) {
 	testCase{
 		Schema: Integer{
-			MetaData: MetaData{
-				Title:       "my-title",
-				Description: "my-description",
-			},
-			Minimum: -240,
-			Maximum: 240,
+			Title:       "my-title",
+			Description: "my-description",
+			Minimum:     -240,
+			Maximum:     240,
 		},
 		Match: `{
       "type": "integer",
@@ -104,12 +102,10 @@ func TestNumber(t *testing.T) {
 	var h int8
 	testCase{
 		Schema: Number{
-			MetaData: MetaData{
-				Title:       "my-title",
-				Description: "my-description",
-			},
-			Minimum: -240.5,
-			Maximum: 240,
+			Title:       "my-title",
+			Description: "my-description",
+			Minimum:     -240.5,
+			Maximum:     240,
 		},
 		Match: `{
       "type": "number",
@@ -136,10 +132,8 @@ func TestNumber(t *testing.T) {
 func TestBoolean(t *testing.T) {
 	testCase{
 		Schema: Boolean{
-			MetaData: MetaData{
-				Title:       "my-title",
-				Description: "my-description",
-			},
+			Title:       "my-title",
+			Description: "my-description",
 		},
 		Match: `{
       "type": "boolean",
@@ -186,10 +180,8 @@ func TestBoolean(t *testing.T) {
 func TestString(t *testing.T) {
 	testCase{
 		Schema: String{
-			MetaData: MetaData{
-				Title:       "my-title",
-				Description: "my-description",
-			},
+			Title:       "my-title",
+			Description: "my-description",
 		},
 		Match: `{
       "type": "string",
@@ -236,10 +228,8 @@ func TestString(t *testing.T) {
 func TestStringLength(t *testing.T) {
 	testCase{
 		Schema: String{
-			MetaData: MetaData{
-				Title:       "my-title",
-				Description: "my-description",
-			},
+			Title:         "my-title",
+			Description:   "my-description",
 			MinimumLength: 5,
 			MaximumLength: 10,
 		},
@@ -291,11 +281,9 @@ func TestStringLength(t *testing.T) {
 func TestStringPattern(t *testing.T) {
 	testCase{
 		Schema: String{
-			MetaData: MetaData{
-				Title:       "my-title",
-				Description: "my-description",
-			},
-			Pattern: "^[a-z]+$",
+			Title:       "my-title",
+			Description: "my-description",
+			Pattern:     "^[a-z]+$",
 		},
 		Match: `{
       "type": "string",
@@ -344,10 +332,8 @@ func TestStringPattern(t *testing.T) {
 func TestStringEnum(t *testing.T) {
 	testCase{
 		Schema: StringEnum{
-			MetaData: MetaData{
-				Title:       "my-title",
-				Description: "my-description",
-			},
+			Title:       "my-title",
+			Description: "my-description",
 			Options: []string{
 				"a", "b", "c--",
 			},
@@ -402,10 +388,8 @@ func TestURI(t *testing.T) {
 	var pu *url.URL
 	testCase{
 		Schema: URI{
-			MetaData: MetaData{
-				Title:       "my-title",
-				Description: "my-description",
-			},
+			Title:       "my-title",
+			Description: "my-description",
 		},
 		Match: `{
       "type": "string",
@@ -459,10 +443,8 @@ func TestDate(t *testing.T) {
 	var pDateTime *time.Time
 	testCase{
 		Schema: DateTime{
-			MetaData: MetaData{
-				Title:       "my-title",
-				Description: "my-description",
-			},
+			Title:       "my-title",
+			Description: "my-description",
 		},
 		Match: `{
       "type": "string",
@@ -586,10 +568,8 @@ func TestDuration(t *testing.T) {
 	pattern, _ := json.Marshal(signedDurationRegexp.String())
 	testCase{
 		Schema: Duration{
-			MetaData: MetaData{
-				Title:       "my-title",
-				Description: "my-description",
-			},
+			Title:         "my-title",
+			Description:   "my-description",
 			AllowNegative: true,
 		},
 		Match: `{


### PR DESCRIPTION
I think this is a reasonable thing to break over...

It's small, but it's really annoying when we're writing schemas in tc-worker...

there is an argument for this change here:
https://github.com/taskcluster/taskcluster-worker/issues/222

Note: yes, this is breaking, but tc-worker is vendored, I don't think anyone else depends on this..
Besides, we never promised this was stable :)